### PR TITLE
refactor: Apply import-order rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,6 +20,22 @@ module.exports = {
     '@typescript-eslint/no-misused-promises': 'warn',
     '@typescript-eslint/strict-boolean-expressions': 0,
     '@typescript-eslint/promise-function-async': 0,
+    'import/order': [
+      'error',
+      {
+        'newlines-between': 'always',
+        alphabetize: { order: 'asc', caseInsensitive: true },
+        groups: ['builtin', 'external', 'internal', 'unknown', ['parent', 'sibling', 'index']],
+        pathGroups: [
+          {
+            pattern: '@{app,components,pages,images,redux,assets,utils,service}/**',
+            group: 'external',
+            position: 'after',
+          },
+        ],
+        pathGroupsExcludedImportTypes: ['builtin'],
+      },
+    ],
   },
   ignorePatterns: ['.eslintrc.js'],
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
-import Home from '@src/pages/home';
-import Detail from '@src/pages/detail';
-import Mypage from '@src/pages/myPage';
+
+import Detail from './pages/Detail';
+import Home from './pages/Home';
+import Mypage from './pages/Mypage';
+
 
 const App: React.FC = () => {
   return (

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -1,7 +1,8 @@
 import { configureStore } from '@reduxjs/toolkit';
-import userSlice from '@src/redux/userSlice';
 import { useDispatch, useSelector } from 'react-redux';
 import type { TypedUseSelectorHook } from 'react-redux';
+
+import userSlice from '@redux/userSlice';
 
 const store = configureStore({
   reducer: {

--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { Button as AntdButton } from 'antd';
+import React from 'react';
 import '@assets/button.scss';
 
 interface Props {

--- a/src/components/checkboxGroup/index.tsx
+++ b/src/components/checkboxGroup/index.tsx
@@ -1,8 +1,8 @@
 import { Checkbox } from 'antd';
 import type { CheckboxChangeEvent } from 'antd/es/checkbox';
+import type { CheckboxValueType } from 'antd/es/checkbox/Group';
 import React, { Dispatch, SetStateAction, useState, useEffect } from 'react';
 import styled from 'styled-components';
-import type { CheckboxValueType } from 'antd/es/checkbox/Group';
 
 interface CheckboxGroupProps {
   options: Array<{ label: string; value: string | number }>;

--- a/src/components/commonLayout/header.tsx
+++ b/src/components/commonLayout/header.tsx
@@ -1,12 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import styled from 'styled-components';
+
+import type { RootState } from '@app/store';
+import { useAppDispatch, useAppSelector } from '@app/store';
 import Button from '@components/button';
 import Modal from '@components/modal';
+import { getUserInfoByToken } from '@redux/userSlice';
 import { signInWithGoogle, signOutGoogle } from '@utils/firebase';
-import { useAppDispatch, useAppSelector } from '@src/app/store';
-import type { RootState } from '@src/app/store';
-import { getUserInfoByToken } from '@src/redux/userSlice';
 
 const AbsoluteHeader = styled.div`
   position: relative;

--- a/src/components/commonLayout/index.tsx
+++ b/src/components/commonLayout/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import Header from './header';
 import styled from 'styled-components';
+
+import Header from './header';
 
 const Body = styled.div`
   width: 100%;

--- a/src/components/modal/index.tsx
+++ b/src/components/modal/index.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from 'react';
 import { Modal } from 'antd';
+import React, { useEffect, useState } from 'react';
 import '@assets/modal.scss';
 
 interface ModalProps {

--- a/src/components/radioGroup/index.tsx
+++ b/src/components/radioGroup/index.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
 import type { RadioChangeEvent } from 'antd';
 import { Radio } from 'antd';
+import React from 'react';
 
 interface RadioGroupProps {
   options: Array<{ label: string; value: string | number }>;

--- a/src/components/search/index.tsx
+++ b/src/components/search/index.tsx
@@ -1,6 +1,6 @@
-import React, { Dispatch, useState, SetStateAction } from 'react';
 import { Select } from 'antd';
 import { AxiosResponse } from 'axios';
+import React, { Dispatch, useState, SetStateAction } from 'react';
 
 const { Option } = Select;
 

--- a/src/components/searchSelect/index.tsx
+++ b/src/components/searchSelect/index.tsx
@@ -1,7 +1,8 @@
-import React, { Dispatch, SetStateAction, useContext, useState } from 'react';
 import { Select } from 'antd';
-import { MatchInfoContext } from '@src/pages/home/matchSelector/MatchInfoProvider';
-import { getStadiumList } from '@src/service/stadiumApi';
+import React, { Dispatch, SetStateAction, useContext, useState } from 'react';
+
+import { MatchInfoContext } from '@pages/Home/matchSelector/MatchInfoProvider';
+import { getStadiumList } from '@service/stadiumApi';
 
 const { Option } = Select;
 const dummy = ['강남구', '마포구', '송파구'];

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import './index.css';
+import { Provider } from 'react-redux';
+
 import App from './App';
 import store from './app/store';
-import { Provider } from 'react-redux';
+
+import './index.css';
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement,

--- a/src/pages/Detail/index.tsx
+++ b/src/pages/Detail/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import CommonLayout from '@src/components/commonLayout';
+
+import CommonLayout from '@components/commonLayout';
 
 const Detail = () => {
   return <CommonLayout>detail page</CommonLayout>;

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -1,13 +1,16 @@
-import React, { useEffect } from 'react';
-import '@assets/home.scss';
 import { Carousel } from 'antd';
-import CommonLayout from '@src/components/commonLayout';
-import MatchSelector from './matchSelector';
 import axios from 'axios';
+import React, { useEffect } from 'react';
 import styled from 'styled-components';
+
 import Img1 from '@assets/images/football1.jpg';
 import Img2 from '@assets/images/football2.jpg';
 import Img3 from '@assets/images/football3.jpg';
+import CommonLayout from '@components/commonLayout';
+
+import MatchSelector from './matchSelector';
+
+import '@assets/home.scss';
 
 const MatchContainer = styled.div`
   width: 100%;

--- a/src/pages/Home/matchSelector/dateSelect.tsx
+++ b/src/pages/Home/matchSelector/dateSelect.tsx
@@ -1,10 +1,11 @@
-import React, { useContext, useState, useEffect } from 'react';
-import { DatePicker as AntdDatePicker, ConfigProvider } from 'antd';
-import type { DatePickerProps } from 'antd';
-import 'moment/locale/ko';
+import { DatePicker as AntdDatePicker, ConfigProvider, DatePickerProps } from 'antd';
 import locale from 'antd/es/locale/ko_KR';
-import { MatchInfoContext } from './MatchInfoProvider';
 import moment from 'moment';
+import React, { useContext, useState, useEffect } from 'react';
+
+import { MatchInfoContext } from './MatchInfoProvider';
+
+import 'moment/locale/ko';
 
 const DatePicker = () => {
   const { matchData, setMatchData } = useContext(MatchInfoContext);

--- a/src/pages/Home/matchSelector/filterMatch.tsx
+++ b/src/pages/Home/matchSelector/filterMatch.tsx
@@ -1,8 +1,10 @@
+import { Select } from 'antd';
 import React, { useContext, useState, useEffect } from 'react';
 import styled from 'styled-components';
+
 import SearchInput from '@components/searchSelect';
-import Tag from '@src/components/tag';
-import { Select } from 'antd';
+import Tag from '@components/tag';
+
 import { MatchInfoContext } from './MatchInfoProvider';
 
 const { Option } = Select;

--- a/src/pages/Home/matchSelector/index.tsx
+++ b/src/pages/Home/matchSelector/index.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { MatchInfoProvider } from './MatchInfoProvider';
+
 import DateSelect from './dateSelect';
 import FilterMatch from './filterMatch';
+import { MatchInfoProvider } from './MatchInfoProvider';
 import MatchList from './matchList';
 
 const MatchSelector = () => {

--- a/src/pages/Home/matchSelector/matchList.tsx
+++ b/src/pages/Home/matchSelector/matchList.tsx
@@ -1,8 +1,10 @@
-import React, { useContext, useEffect, useState } from 'react';
-import { MatchInfoContext } from './MatchInfoProvider';
 import { List } from 'antd';
+import React, { useContext, useEffect, useState } from 'react';
+
 import { getMatches } from '@service/matchApi';
 import { MATCH_NUM_TO_STRING, GENDER_TO_KOR } from '@utils/parse';
+
+import { MatchInfoContext } from './MatchInfoProvider';
 
 interface MatchListProps {
   id: number;

--- a/src/pages/Mypage/admin/index.tsx
+++ b/src/pages/Mypage/admin/index.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
-import Button from '@src/components/button';
 import styled from 'styled-components';
+
+import Button from '@components/button';
+
 import MatchCreateModal from './matchCreateModal';
 import StadiumCreateModal from './stadiumCreateModal';
 

--- a/src/pages/Mypage/admin/matchCreateModal/index.tsx
+++ b/src/pages/Mypage/admin/matchCreateModal/index.tsx
@@ -1,18 +1,17 @@
-import React, { useState, useEffect } from 'react';
-import Modal from '@components/modal';
-import type { ModalProps } from '@components/modal';
-import InputForm, { Section } from '@src/components/inputForm';
 import { DatePicker, Input } from 'antd';
 import type { DatePickerProps } from 'antd';
-import 'moment/locale/ko';
-import locale from 'antd/es/locale/ko_KR';
-import moment from 'moment';
-import Search from '@components/search';
-import { getStadiumList } from '@service/stadiumApi';
-import RadioGroup from '@components/radioGroup';
-import Button from '@src/components/button';
-import { createMatch } from '@service/matchApi';
+import React, { useState, useEffect } from 'react';
 
+import Button from '@components/button';
+import InputForm, { Section } from '@components/inputForm';
+import Modal from '@components/modal';
+import type { ModalProps } from '@components/modal';
+import RadioGroup from '@components/radioGroup';
+import Search from '@components/search';
+import { createMatch } from '@service/matchApi';
+import { getStadiumList } from '@service/stadiumApi';
+
+import 'moment/locale/ko';
 interface MatchInfoProps {
   startAt: string;
   stadiumId: number;

--- a/src/pages/Mypage/admin/stadiumCreateModal/index.tsx
+++ b/src/pages/Mypage/admin/stadiumCreateModal/index.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+
 import Modal from '@components/modal';
 import type { ModalProps } from '@components/modal';
 

--- a/src/pages/Mypage/index.tsx
+++ b/src/pages/Mypage/index.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
-import CommonLayout from '@src/components/commonLayout';
 import styled from 'styled-components';
-import { useAppSelector } from '@src/app/store';
+
+import { useAppSelector } from '@app/store';
+import CommonLayout from '@components/commonLayout';
+
 import AdminMyPage from './admin';
 import UserMyPage from './user';
 

--- a/src/redux/userSlice.ts
+++ b/src/redux/userSlice.ts
@@ -1,5 +1,6 @@
-import { getUserAPI } from '@service/api';
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+
+import { getUserAPI } from '@service/api';
 
 interface UserKeys {
   uid: number;

--- a/src/service/api.ts
+++ b/src/service/api.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
-import { apiUrl } from './config';
+
 import authHeader from './authHeader';
+import { apiUrl } from './config';
 
 export const getUserAPI = (token: string) => {
   // return axios.get(`${apiUrl}/users/me`, {

--- a/src/service/matchApi.ts
+++ b/src/service/matchApi.ts
@@ -1,6 +1,7 @@
 import axios, { AxiosError, AxiosResponse } from 'axios';
-import { apiUrl } from './config';
+
 import authHeader from './authHeader';
+import { apiUrl } from './config';
 
 const matchAxios = axios.create({ baseURL: `${apiUrl}/matches` });
 // matchAxios.interceptors.response.use(

--- a/src/service/stadiumApi.ts
+++ b/src/service/stadiumApi.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
-import { apiUrl } from './config';
+
 import authHeader from './authHeader';
+import { apiUrl } from './config';
 
 // Question
 // const token = authHeader()을 함수 실행 전 매번 붙여줘야 한다.

--- a/src/utils/firebase.ts
+++ b/src/utils/firebase.ts
@@ -9,8 +9,9 @@ import {
   signInWithPopup,
   signOut,
 } from 'firebase/auth';
-import { useAppDispatch, useAppSelector } from '@src/app/store';
-import { getUserInfoByToken } from '@src/redux/userSlice';
+
+import { useAppDispatch, useAppSelector } from '@app/store';
+import { getUserInfoByToken } from '@redux/userSlice';
 
 // Your web app's Firebase configuration
 // For Firebase JS SDK v7.20.0 and later, measurementId is optional

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@src/*": ["src/*"],
+      "@app/*": ["src/app/*"],
       "@components/*": ["src/components/*"],
       "@pages/*": ["src/pages/*"],
       "@images/*": ["src/images/*"],


### PR DESCRIPTION
import 순서가 일정하지 않아, Import/order 룰을 추가하고 lint fix 돌렸습니다~

* `\@src` 는 의미가 크지 않기 때문에 지양하는편이 좋습니다 
* 외부 라이브러리는 맨 위에, 한솔님이 작성하신 코드는 중간에, `import ''` 는 가장 아래에 위치하게 자동 정렬됩니다



참고 : https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/order.md